### PR TITLE
Add test for checking whether the admin group is deleted with an algo…

### DIFF
--- a/app/comic/eyra_algorithms/models.py
+++ b/app/comic/eyra_algorithms/models.py
@@ -127,6 +127,11 @@ class Algorithm(UUIDModel):
         help_text="The admin group associated with this algorithm",
     )
 
+    def delete(self, *args, **kwargs):
+        if self.admin_group:
+            self.admin_group.delete()
+        return super().delete(*args, **kwargs)
+
     def __str__(self):
         return self.name
 

--- a/app/tests/eyra_algorithms/test_algorithm_deletion.py
+++ b/app/tests/eyra_algorithms/test_algorithm_deletion.py
@@ -1,0 +1,27 @@
+from django.contrib.auth.models import Group
+
+from rest_framework.test import APITestCase
+
+from comic.eyra_algorithms.models import Algorithm
+from tests.factories import AlgorithmFactory, UserFactory
+
+
+class AlgorithmDeleteTest(APITestCase):
+    def test_delete_admin_group_with_algorithm(self):
+        user = UserFactory()
+        algorithm: Algorithm = AlgorithmFactory(
+            creator=user
+        )
+
+        algorithm_pk = algorithm.pk
+        admin_group_pk = algorithm.admin_group.pk
+
+        algorithm.delete()
+
+        # algorithm does not exist
+        with self.assertRaises(Algorithm.DoesNotExist):
+            Algorithm.objects.get(pk=algorithm_pk)
+
+        # admin group does not exist
+        with self.assertRaises(Group.DoesNotExist):
+            Group.objects.get(pk=admin_group_pk)


### PR DESCRIPTION
…rithm

Admin groups are not deleted when an algorithm is deleted using the
admin interface. For a solution to this see:
https://stackoverflow.com/questions/12754024/onetoonefield-and-deleting